### PR TITLE
Allow disabling locus line truncation when writing records

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ include!(concat!(env!("OUT_DIR"), "/atoms.rs")); // for QualifierKey, FeatureKin
 
 pub mod seq;
 pub mod reader;
-mod writer;
+pub mod writer;
 
 #[cfg(test)]
 pub mod tests {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -45,7 +45,7 @@ impl<W: Write> SeqWriter<W> {
     pub fn new(stream: W) -> Self {
         Self {
             stream,
-            truncate_locus: true,
+            truncate_locus: false,
             escape_locus: true,
         }
     }
@@ -182,7 +182,7 @@ impl<W: Write> SeqWriter<W> {
                 )?;
                 for &(ref key, ref val) in &f.qualifiers {
                     match *val {
-                        None => write!(&mut self.stream, "{}/{}\n", QUALIFIER_INDENT, key)?,
+                        None => writeln!(&mut self.stream, "{}/{}", QUALIFIER_INDENT, key)?,
                         Some(ref val) => {
                             let quote = !FTQUAL_NO_QUOTE.iter().any(|x| x == key);
                             let first_indent = format!("{}/{}=", QUALIFIER_INDENT, key);


### PR DESCRIPTION
Hi David!

First of all let me thank you for this library, it has turned my GenBank parsing experience from painfully slow (1 hour with Biopython) to really fast (8 minutes with `gb-io`) when processing very large sequence predictions. I'm using it very often in read-only mode to analyze large-scale predictions.

However, I've not been very succesful with the writer: because I'm working on metagenomic data, it's not unusual for locus tags to be very long, and normally with Biopython I'd be able to write these (with a warning), but the formatter in `gb-io` will forcefully truncate them. This has resulted in quite painful bugs (`very_long_id_143` becoming `very_long_id_14` and all of a sudden i have plenty of duplicates) before I realized what was going on... Since most parser are eventually able to process these "long locus lines", I think it should be better if the library user (e.g. me) could choose to disable this, if they know that the files can be processed later by whatever parser they will read the GenBank with.

This PR adds a configurable `SeqWriter` that wraps a `Write` implementor, which can be configured with a builder pattern. I added flags to disable locus tag escaping and truncation, which are enabled by default for backwards compatibility.