### PR TITLE
Retain spaces when splitting long lines

### DIFF
--- a/src/reader/streaming_parser.rs
+++ b/src/reader/streaming_parser.rs
@@ -238,8 +238,8 @@ impl<T: Read> StreamParser<T> {
 
     pub fn read_one_record(&mut self) -> Result<Option<Seq>, GbParserError> {
         // skip preamble such as the header of Genbank .SEQ files
-        self.try_run_parser(&skip_preamble, false)?;
-        let locus = match self.run_parser(&locus, true) {
+        self.try_run_parser(skip_preamble, false)?;
+        let locus = match self.run_parser(locus, true) {
             Ok(locus) => locus,
             Err(StreamParserError::EOF) => {
                 return Ok(None);
@@ -257,14 +257,14 @@ impl<T: Read> StreamParser<T> {
             division: locus.division,
             ..Seq::empty()
         };
-        let fields = self.run_parser_many0(&any_field)?;
+        let fields = self.run_parser_many0(any_field)?;
         let mut seq = fill_seq_fields(seq, fields).map_err(GbParserError::SyntaxError)?; //TODO: Proper error handling
-        if self.try_run_parser(&features_header, true)?.is_some() {
-            seq.features = self.run_parser_many0(&feature)?;
+        if self.try_run_parser(features_header, true)?.is_some() {
+            seq.features = self.run_parser_many0(feature)?;
         }
-        self.try_run_parser(&base_count, true)?;
-        seq.contig = self.try_run_parser(&contig_text, true)?;
-        if self.try_run_parser(&origin_tag, true)?.is_some() {
+        self.try_run_parser(base_count, true)?;
+        seq.contig = self.try_run_parser(contig_text, true)?;
+        if self.try_run_parser(origin_tag, true)?.is_some() {
             seq.seq = self.parse_seq_data(seq.len)?;
         }
 
@@ -274,8 +274,8 @@ impl<T: Read> StreamParser<T> {
             return Ok(Some(seq));
         }
 
-        self.run_parser(&double_slash, true)?;
-        self.run_parser_many0(&line_ending_type_hack)?;
+        self.run_parser(double_slash, true)?;
+        self.run_parser_many0(line_ending_type_hack)?;
         Ok(Some(seq))
     }
 }

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -12,7 +12,7 @@ use crate::dna::revcomp;
 pub use crate::{FeatureKind, QualifierKey};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 /// A very simple Date struct so we don't have to rely on chrono
 pub struct Date {
     year: i32,
@@ -20,7 +20,7 @@ pub struct Date {
     day: u32,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DateError;
 
 impl Date {
@@ -66,7 +66,7 @@ impl fmt::Display for Date {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum GapLength {
     /// gap(n)
     Known(i64),
@@ -77,10 +77,10 @@ pub enum GapLength {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Before(pub bool);
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct After(pub bool);
 
 /// Represents a Genbank "location", used to specify the location of
@@ -351,7 +351,7 @@ impl Feature {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Topology {
     Linear,
     Circular,
@@ -368,14 +368,14 @@ impl fmt::Display for Topology {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Source {
     pub source: String,
     pub organism: Option<String>,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Reference {
     pub description: String,
     pub authors: Option<String>,


### PR DESCRIPTION
When long qualifier values are split on spaces to keep the total line length less than 80 characters, and the final character on a line is a space, that space is deleted. However, this prevents parsing the original value - it's not possible to know when joining the lines together whether a space should be inserted or not. For example:

`Lipopolysaccharide export system ATP-binding protein LptB`

will appear in the Genbank text as:

```
/product="Lipopolysaccharide export system ATP-binding
 protein LptB"
```

and when this is read later and newlines are removed, it will be:

`Lipopolysaccharide export system ATP-bindingprotein LptB`
(note `bindingprotein` is one word now).

This commit retains the final space at the end of the line so that the original value can be reconstructed unambiguously.